### PR TITLE
Fixed confluence configuration bug + removed application.conf from jar package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,5 +51,6 @@ build/
 akka-patterns-store/
 hubble-core/src/main/resources/DONT_ADD/
 hubble-core/export.xlsx
-hubble-core/src/main/resources/application.conf
 hubble-reporting/export.xlsx
+
+**/application.conf

--- a/hubble-core/assembly.xml
+++ b/hubble-core/assembly.xml
@@ -1,0 +1,26 @@
+<assembly
+        xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+
+    <id>config</id>
+
+    <formats>
+        <format>jar</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <unpack>true</unpack>
+            <scope>runtime</scope>
+            <unpackOptions>
+                <excludes>
+                    <exclude>application.conf</exclude>
+                </excludes>
+            </unpackOptions>
+        </dependencySet>
+    </dependencySets>
+
+</assembly>

--- a/hubble-core/assembly.xml
+++ b/hubble-core/assembly.xml
@@ -3,7 +3,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
 
-    <id>config</id>
+    <id>jar-with-dependencies</id>
 
     <formats>
         <format>jar</format>

--- a/hubble-core/pom.xml
+++ b/hubble-core/pom.xml
@@ -80,41 +80,6 @@
 			<artifactId>snappy-java</artifactId>
 			<version>1.1.1.7</version>
 		</dependency>
-		<!--<dependency>-->
-			<!--<groupId>org.apache.spark</groupId>-->
-			<!--<artifactId>spark-core_2.11</artifactId>-->
-			<!--<version>1.4.1</version>-->
-		<!--</dependency>-->
-		<!--<dependency>-->
-			<!--<groupId>org.apache.spark</groupId>-->
-			<!--<artifactId>spark-sql_2.11</artifactId>-->
-			<!--<version>1.4.1</version>-->
-		<!--</dependency>-->
-		<!--<dependency>-->
-		<!--<groupId>com.atlassian.confluence</groupId>-->
-		<!--<artifactId>confluence</artifactId>-->
-		<!--<version>5.8.5</version>-->
-		<!--</dependency>-->
-		<!--<dependency>-->
-		<!--<groupId>com.typesafe.play</groupId>-->
-		<!--<artifactId>play_2.11</artifactId>-->
-		<!--<version>2.4.0-M3</version>-->
-		<!--</dependency>-->
-		<!--<dependency>-->
-		<!--<groupId>com.typesafe.play</groupId>-->
-		<!--<artifactId>play-json_2.11</artifactId>-->
-		<!--<version>2.3.0</version>-->
-		<!--</dependency>-->
-		<!--<dependency>-->
-		<!--<groupId>com.typesafe.play</groupId>-->
-		<!--<artifactId>play-ws_2.11</artifactId>-->
-		<!--<version>2.4.0-M3</version>-->
-		<!--</dependency>-->
-		<!--<dependency>-->
-		<!--<groupId>org.yaml</groupId>-->
-		<!--<artifactId>snakeyaml</artifactId>-->
-		<!--<version>1.16-SNAPSHOT</version>-->
-		<!--</dependency>-->
 		<dependency>
 			<groupId>org.scalaj</groupId>
 			<artifactId>scalaj-http_2.11</artifactId>
@@ -126,16 +91,6 @@
 			<artifactId>spray-json_2.11</artifactId>
 			<version>1.3.1</version>
 		</dependency>
-		<!--<dependency>-->
-		<!--<groupId>com.fasterxml.jackson.module</groupId>-->
-		<!--<artifactId>jackson-module-scala_2.11</artifactId>-->
-		<!--<version>2.5.2</version>-->
-		<!--</dependency>-->
-		<!--<dependency>-->
-		<!--<groupId>org.json4s</groupId>-->
-		<!--<artifactId>json4s-native_2.11</artifactId>-->
-		<!--<version>3.2.11</version>-->
-		<!--</dependency>-->
 		<dependency>
 			<groupId>org.json4s</groupId>
 			<artifactId>json4s-jackson_2.11</artifactId>
@@ -174,14 +129,12 @@
 				<artifactId>maven-assembly-plugin</artifactId>
 				<version>2.4</version>
 				<configuration>
-					<descriptorRefs>
-						<descriptorRef>jar-with-dependencies</descriptorRef>
-					</descriptorRefs>
 					<archive>
 						<manifest>
 							<mainClass>team.supernova.ClusterInfoApp</mainClass>
 						</manifest>
 					</archive>
+					<descriptor>assembly.xml</descriptor>
 				</configuration>
 				<executions>
 					<execution>

--- a/hubble-core/src/main/scala/team/supernova/ClusterInfoApp.scala
+++ b/hubble-core/src/main/scala/team/supernova/ClusterInfoApp.scala
@@ -15,8 +15,8 @@ object ClusterInfoApp extends App {
 
   def startScheduleEveryDay() = {
     import system.dispatcher
-    val GROUP = system.settings.config.getString("confluence.group")
-    val SPACE = system.settings.config.getString("confluence.space")
+    val GROUP = system.settings.config.getString("hubble.confluence.group")
+    val SPACE = system.settings.config.getString("hubble.confluence.space")
     val app = system.actorOf(ClusterInfoCollector.props(SPACE, GROUP, TOKEN))
     system.scheduler.schedule(0 milliseconds, 24 hours, app, ClusterInfoCollector.Start(GROUP, cassandraSession))
   }

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,6 @@
                 <filtering>true</filtering>
                 <includes>
                     <include>**/*.properties</include>
-                    <include>**/*.conf</include>
                 </includes>
             </testResource>
         </testResources>

--- a/pom.xml
+++ b/pom.xml
@@ -82,15 +82,6 @@
                 </includes>
             </testResource>
         </testResources>
-        <resources>
-            <resource>
-                <directory>src/main/resources</directory>
-                <excludes>
-                    <exclude>application.conf</exclude>
-                </excludes>
-                <filtering>true</filtering>
-            </resource>
-        </resources>
         <!--<resources>-->
             <!--<resource>-->
                 <!--<directory>src/main/resources</directory>-->

--- a/pom.xml
+++ b/pom.xml
@@ -79,9 +79,19 @@
                 <filtering>true</filtering>
                 <includes>
                     <include>**/*.properties</include>
+                    <include>**/*.conf</include>
                 </includes>
             </testResource>
         </testResources>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <excludes>
+                    <exclude>application.conf</exclude>
+                </excludes>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <!--<resources>-->
             <!--<resource>-->
                 <!--<directory>src/main/resources</directory>-->


### PR DESCRIPTION
Fixed confluence configuration bug: space and group was not picked up
removed application.conf from jar package. You can run the jar by providing application.conf from outside. example:
java -Dconfig.file='{some-location}/application.conf' -jar hubble-core-1.0-SNAPSHOT-jar-with-dependencies.jar
