### PR TITLE
configurations on application.conf

### DIFF
--- a/hubble-core/src/main/resources/application.conf.example
+++ b/hubble-core/src/main/resources/application.conf.example
@@ -1,16 +1,32 @@
 hubble {
   cassandra {
-    username = the user to connect to Cassandra
-    password = the password to connect to Cassandra
-    keyspace = the keyspace which you want to connect to
-    hosts = hosts list (comma separated) for connecting to Cassandra (e.g. "hostname1,hostname2")
-    port = port used to connect to Cassandra (e.g. 9042)
+     clusters = [
+          {
+            name = the group name that defines different environments of the same type of cluster this name is also the space you want to write to (e.g. "CLUSTER_1")
+            envs = [
+              {
+                cluster_name = the actual cluster name that cassandra cluster defines itself by. These Clusters are the DTAP for certain group (ex. "CLUSTER_1_DEV")
+                graphana = the host name of graphana. format is "serverHostname:port"
+                graphite = the host name of graphana. format is "serverHostname"
+                hosts = [
+                  hosts list for connecting to Cassandra (e.g. "hostname1,hostname2")
+                ]
+                port = port used to connect to Cassandra (e.g. 9042)
+                pword = the password to connect to Cassandra
+                uname = the user to connect to Cassandra
+                opscenter = the host name of opscenter. format is "serverHostname:port"
+                ops_pword = password for the opsCenter Server
+                ops_uname = username for the opsCenter Server
+                sequence = Order by which the clusters within a group should be processed and shown in confluence
+              }
+              ]
+          }
+        ]
   }
   confluence {
     user = the user used for connecting to Confluence
     password = the password used for connecting to Confluence
     endpointaddress = the url of the Confluence SOAP endpoint (e.g. "https://hostname/plugins/servlet/soap-axis1/confluenceservice-v2")
     space = the Confluence space where you want to write the pages to (e.g. "CASSANDRA")
-    group = the page group on the space you want to write to (e.g. "CLUSTER_1")
   }
 }

--- a/hubble-core/src/main/scala/team/supernova/ClusterInfoApp.scala
+++ b/hubble-core/src/main/scala/team/supernova/ClusterInfoApp.scala
@@ -2,8 +2,11 @@ package team.supernova
 
 import akka.actor.ActorSystem
 import com.datastax.driver.core.{Cluster, ProtocolOptions, Session}
-import team.supernova.actor.ClusterInfoCollector
+import com.typesafe.config.Config
+import team.supernova.actor.{CassandraClusterGroup, ClusterEnv, ClusterInfoCollector}
 import team.supernova.confluence.ConfluenceToken
+
+import scala.collection.JavaConversions._
 import scala.concurrent.duration._
 
 object ClusterInfoApp extends App {
@@ -15,24 +18,25 @@ object ClusterInfoApp extends App {
 
   def startScheduleEveryDay() = {
     import system.dispatcher
-    val GROUP = system.settings.config.getString("hubble.confluence.group")
     val SPACE = system.settings.config.getString("hubble.confluence.space")
-    val app = system.actorOf(ClusterInfoCollector.props(SPACE, GROUP, TOKEN))
-    system.scheduler.schedule(0 milliseconds, 24 hours, app, ClusterInfoCollector.Start(GROUP, cassandraSession))
+
+    val clusters = mapConfigToCassandraClusterGroup(system.settings.config)
+    val app = system.actorOf(ClusterInfoCollector.props(SPACE, TOKEN))
+    ClusterInfoCollector.Start(clusters)
   }
 
-  def cassandraSession: Session = {
-    val username = system.settings.config.getString("hubble.cassandra.username")
-    val password = system.settings.config.getString("hubble.cassandra.password")
-    val port = system.settings.config.getInt("hubble.cassandra.port")
-    val keyspace = system.settings.config.getString("hubble.cassandra.keyspace")
-    val hosts = system.settings.config.getString("hubble.cassandra.hosts").split(",").toList
-    Cluster.builder().
-      addContactPoints(hosts: _*).
-      withCompression(ProtocolOptions.Compression.SNAPPY).
-      withPort(port).
-      withCredentials(username, password).
-      build().
-      connect(keyspace)
+  def mapConfigToClusterEnv(pr: Config): ClusterEnv = {
+    new ClusterEnv(pr.getString("cluster_name"),
+      pr.getString("graphana"),
+      pr.getString("graphite"),
+      pr.getStringList("hosts").map(_.toString).toArray, pr.getString("ops_pword"), pr.getString("ops_uname"), pr.getString("opscenter"),
+      pr.getInt("port"), pr.getString("pword"), pr.getString("uname"), pr.getInt("sequence"))
+  }
+
+  def mapConfigToCassandraClusterGroup(config: Config): List[CassandraClusterGroup] = {
+    config.getConfigList("hubble.cassandra.clusters")
+      .map({ p: Config => new CassandraClusterGroup(p.getString("name"), p.getConfigList("envs")
+      map mapConfigToClusterEnv toList)
+    }).toList
   }
 }

--- a/hubble-core/src/main/scala/team/supernova/ClusterInfoApp.scala
+++ b/hubble-core/src/main/scala/team/supernova/ClusterInfoApp.scala
@@ -3,6 +3,7 @@ package team.supernova
 import akka.actor.ActorSystem
 import com.datastax.driver.core.{Cluster, ProtocolOptions, Session}
 import com.typesafe.config.Config
+import team.supernova.actor.ClusterInfoCollector.Start
 import team.supernova.actor.{CassandraClusterGroup, ClusterEnv, ClusterInfoCollector}
 import team.supernova.confluence.ConfluenceToken
 
@@ -22,7 +23,7 @@ object ClusterInfoApp extends App {
 
     val clusters = mapConfigToCassandraClusterGroup(system.settings.config)
     val app = system.actorOf(ClusterInfoCollector.props(SPACE, TOKEN))
-    ClusterInfoCollector.Start(clusters)
+    app ! Start(clusters)
   }
 
   def mapConfigToClusterEnv(pr: Config): ClusterEnv = {

--- a/hubble-core/src/main/scala/team/supernova/actor/ClusterInfoCollector.scala
+++ b/hubble-core/src/main/scala/team/supernova/actor/ClusterInfoCollector.scala
@@ -5,19 +5,19 @@ import com.datastax.driver.core.Session
 import team.supernova.confluence.soap.rpc.soap.actions.Token
 
 object ClusterInfoCollector {
-  case class Start(clusterGroup: String, session: Session)
-  def props(space: String, group: String, token: Token): Props = Props(new ClusterInfoCollector(space, group, token))
+  case class Start(clusters: List[CassandraClusterGroup])
+  def props(space: String, token: Token): Props = Props(new ClusterInfoCollector(space, token))
 }
 
-class ClusterInfoCollector(sSpace: String, sGroup: String, token: Token) extends Actor with ActorLogging {
+class ClusterInfoCollector(sSpace: String, token: Token) extends Actor with ActorLogging {
 
   val group = context.system.actorOf(ClusterInfoController.props(self))
-  val pages = context.system.actorOf(ConfluencePage.props(sSpace, sGroup, token))
+  val pages = context.system.actorOf(ConfluencePage.props(sSpace, token))
 
   override def receive: Receive = {
-    case ClusterInfoCollector.Start(clusterGroup, session) => {
+    case ClusterInfoCollector.Start(clusters) => {
       log.info("START: generate Confluence pages")
-      group ! ClusterInfoController.RetrieveAllClusterInfo(clusterGroup, session)
+      group ! ClusterInfoController.RetrieveAllClusterInfo(clusters)
     }
     case ClusterInfoController.AllClusterInfoRetrieved(allClusters) => {
       log.info(s"All ClusterInfo retrieved for group: $group")

--- a/hubble-core/src/main/scala/team/supernova/actor/ClusterInfoWorker.scala
+++ b/hubble-core/src/main/scala/team/supernova/actor/ClusterInfoWorker.scala
@@ -5,20 +5,21 @@ import com.datastax.driver.core._
 import team.supernova.ClusterInfo
 
 object ClusterInfoWorker {
-  case class RetrieveClusterInfo(clusterGroup: String, clusterName: String, hosts: List[String],port: Int, uname: String, pword: String, graphite_host: String,graphana_host: String, ops_hosts: String, ops_uname: String, ops_pword: String, sequence: Int)
+  case class RetrieveClusterInfo(cluster: ClusterEnv, group: String)
   case class ClusterInfoRetrieved(clusterInfo: ClusterInfo)
 }
 
 class ClusterInfoWorker extends Actor with ActorLogging  {
   override def receive: Receive = {
-    case ClusterInfoWorker.RetrieveClusterInfo(clusterGroup, clusterName, hosts, port, uname, pword, graphite_host, graphana_host,ops_hosts, ops_uname, ops_pword, sequence ) => {
-      log.info(s"Get cluster info for $clusterName")
+    case ClusterInfoWorker.RetrieveClusterInfo(cluster, group) => {
+      log.info(s"Get cluster info for ${cluster.cluster_name}")
       //TODO get OpsCenter Info via Actor!
       //val opsCenterClusterInfo = OpsCenter.createOpsCenterClusterInfo(ops_hosts, ops_uname, ops_pword, clusterName )
-      lazy val clusSes: Session = Cluster.builder().addContactPoints(hosts: _*).withCompression(ProtocolOptions.Compression.SNAPPY).withCredentials(uname, pword).withPort(port).build().connect()
+      lazy val clusSes: Session = Cluster.builder().addContactPoints(cluster.hosts: _*).withCompression(ProtocolOptions.Compression.SNAPPY).withCredentials(cluster.uname, cluster.pword).withPort(cluster.port).build().connect()
       //TODO add ops Center Info!!!!! via messages!!!!!
       // val clusterInfo = ClusterInfo(clusSes.getCluster.getMetadata,  opsCenterClusterInfo, graphite_host, graphana_host, sequence)
-      val clusterInfo = ClusterInfo(clusSes.getCluster.getMetadata, graphite_host, graphana_host, sequence, ops_hosts, ops_uname, ops_pword)
+      val clusterInfo = ClusterInfo(clusSes.getCluster.getMetadata, cluster, group)
+      println("clusterInfo: " + clusterInfo)
       clusSes.close()
       sender ! ClusterInfoWorker.ClusterInfoRetrieved(clusterInfo)
     }

--- a/hubble-core/src/main/scala/team/supernova/actor/ConfluencePage.scala
+++ b/hubble-core/src/main/scala/team/supernova/actor/ConfluencePage.scala
@@ -1,23 +1,32 @@
 package team.supernova.actor
 
 import akka.actor.{Props, Actor, ActorLogging}
-import team.supernova.GroupClusters
+import team.supernova.{ClusterInfo, GroupClusters}
 import team.supernova.confluence.GenerateCassandraConfluencePages
 import team.supernova.confluence.soap.rpc.soap.actions.Token
 
+import scala.collection.SortedSet
+
 object ConfluencePage {
   case object Done
-  case class  GenerateAll(allClusters: GroupClusters)
+  case class  GenerateAll(clusterInfoSet: SortedSet[ClusterInfo])
 
-  def props(space: String, group: String, token: Token): Props = Props(new ConfluencePage(space, group, token))
+  def props(space: String, token: Token): Props = Props(new ConfluencePage(space, token))
 }
 
-class ConfluencePage(space: String, group: String, token: Token) extends Actor with ActorLogging {
+class ConfluencePage(space: String, token: Token) extends Actor with ActorLogging {
   override def receive: Receive = {
-    case ConfluencePage.GenerateAll(allClusters) => {
+    case ConfluencePage.GenerateAll(clusterInfoSet) => {
       log.info("Start generating confluence pages")
       // TODO make reactive
-      GenerateCassandraConfluencePages.generateAllConfluencePages(allClusters, space, group, token, false)
+      val clusterMap = clusterInfoSet.groupBy(f => f.group)
+      clusterMap.foreach(
+        map =>
+        {
+          val allClusters = GroupClusters(map._2)
+          GenerateCassandraConfluencePages.generateGroupConfluencePages(allClusters, space, map._1, token, false)
+        }
+      )
       sender ! ConfluencePage.Done
     }
   }

--- a/hubble-core/src/main/scala/team/supernova/confluence/GenerateCassandraConfluencePages.scala
+++ b/hubble-core/src/main/scala/team/supernova/confluence/GenerateCassandraConfluencePages.scala
@@ -178,7 +178,7 @@ object GenerateCassandraConfluencePages {
         <h1>Cluster: {clusterInfo.cluster_name}</h1>
         <p>{ Confluence.confluenceCodeBlock("Errors", clusterErrors ,"none")}
           { Confluence.confluenceCodeBlock("Warnings", clusterWarnings ,"none")}</p>
-          <img src={s"http://${clusterInfo.graphite_host}/render?from=-2hours&until=now&width=400&height=250&target=LLDS.Cassandra.${clusterInfo.cluster_name}.requests.mean&target=LLDS.Cassandra.${clusterInfo.cluster_name}.requests.max&target=LLDS.Cassandra.${clusterInfo.cluster_name}.requests.p99&_uniq=0.8728725090622902"}/>
+          <img src={s"http://${clusterInfo.cluster.graphite}/render?from=-2hours&until=now&width=400&height=250&target=LLDS.Cassandra.${clusterInfo.cluster_name}.requests.mean&target=LLDS.Cassandra.${clusterInfo.cluster_name}.requests.max&target=LLDS.Cassandra.${clusterInfo.cluster_name}.requests.p99&_uniq=0.8728725090622902"}/>
         <h1>Host Information</h1>
         <p>
           <table>
@@ -245,7 +245,7 @@ object GenerateCassandraConfluencePages {
             at +
             <tr>
               <td><a href={s"/display/$project/${clus.cluster_name.replace(" ","+")}"}>{clus.cluster_name}</a></td>
-              <td>{clusterGraphite(clus.cluster_name, clus.graphana_host)}</td>
+              <td>{clusterGraphite(clus.cluster_name, clus.cluster.graphana)}</td>
               <td>{errors.size}</td>
               <td>{warnings.size}</td>
               <td>{ Confluence.confluenceCodeBlock("Error", errors.foldLeft(""){(a,w) => a + w.details + "\n" } ,"none")}
@@ -290,7 +290,7 @@ object GenerateCassandraConfluencePages {
 
   //TODO create Cluster page if not exits and group page if does not exist!
   //TODO CHeck if gets updated the first ever time
-    def generateAllConfluencePages ( allClusters    : GroupClusters,
+    def generateGroupConfluencePages ( allClusters    : GroupClusters,
                                      project        : String,
                                      mainPageName   : String,
                                      token          : Token,
@@ -373,8 +373,9 @@ object GenerateCassandraConfluencePages {
             if (allClusters.clusterInfoList.filter(cList => cList.cluster_name.toUpperCase.equals(cPage.getTitle)).
               flatMap(cl => cl.keyspaces).count(k => k.keyspace_name.toUpperCase.equals(substringAfter(kPage.getTitle," - "))) == 0 )
               {
-                println (s"DELETING page($deletePages): ${kPage.getTitle}")
+                println (s"Found page to be deleted: ${kPage.getTitle}, DeletePage is $deletePages")
                 if (deletePages) {
+                  println (s"DELETING page: ${kPage.getTitle}")
                   page.remove(kPage.getId)
                   println (s"DELETED page: ${kPage.getTitle}")
                 }

--- a/hubble-core/src/test/resources/application.conf.example
+++ b/hubble-core/src/test/resources/application.conf.example
@@ -1,16 +1,32 @@
 hubble {
   cassandra {
-    username = the user to connect to Cassandra
-    password = the password to connect to Cassandra
-    keyspace = the keyspace which you want to connect to
-    hosts = hosts list (comma separated) for connecting to Cassandra (e.g. "hostname1,hostname2")
-    port = port used to connect to Cassandra (e.g. 9042)
+     clusters = [
+          {
+            name = the group name that defines different environments of the same type of cluster this name is also the space you want to write to (e.g. "CLUSTER_1")
+            envs = [
+              {
+                cluster_name = the actual cluster name that cassandra cluster defines itself by. These Clusters are the DTAP for certain group (ex. "CLUSTER_1_DEV")
+                graphana = the host name of graphana. format is "serverHostname:port"
+                graphite = the host name of graphana. format is "serverHostname"
+                hosts = [
+                  hosts list for connecting to Cassandra (e.g. "hostname1,hostname2")
+                ]
+                port = port used to connect to Cassandra (e.g. 9042)
+                pword = the password to connect to Cassandra
+                uname = the user to connect to Cassandra
+                opscenter = the host name of opscenter. format is "serverHostname:port"
+                ops_pword = password for the opsCenter Server
+                ops_uname = username for the opsCenter Server
+                sequence = Order by which the clusters within a group should be processed and shown in confluence
+              }
+              ]
+          }
+        ]
   }
   confluence {
     user = the user used for connecting to Confluence
     password = the password used for connecting to Confluence
     endpointaddress = the url of the Confluence SOAP endpoint (e.g. "https://hostname/plugins/servlet/soap-axis1/confluenceservice-v2")
     space = the Confluence space where you want to write the pages to (e.g. "CASSANDRA")
-    group = the page group on the space you want to write to (e.g. "CLUSTER_1")
   }
 }

--- a/hubble-core/src/test/scala/team/supernova/ClusterInfoSpec.scala
+++ b/hubble-core/src/test/scala/team/supernova/ClusterInfoSpec.scala
@@ -19,7 +19,6 @@ with FunSpecLike //with Matchers with BeforeAndAfterAll
 with TestCassandraCluster {
 
   val TOKEN = ConfluenceToken.getConfluenceToken(system.settings.config)
-  val GROUP = system.settings.config.getString("hubble.confluence.group")
   val SPACE = system.settings.config.getString("hubble.confluence.space")
 
 

--- a/hubble-core/src/test/scala/team/supernova/cassandra.scala
+++ b/hubble-core/src/test/scala/team/supernova/cassandra.scala
@@ -7,18 +7,15 @@ import com.datastax.driver.core.{Cluster, ProtocolOptions, Session}
 trait TestCassandraCluster {
   def system: ActorSystem
 
-  val username = system.settings.config.getString("hubble.cassandra.username")
-  val password = system.settings.config.getString("hubble.cassandra.password")
-  val port = system.settings.config.getString("hubble.cassandra.port").toInt
-  val keyspace = system.settings.config.getString("hubble.cassandra.keyspace")
-  val hosts = system.settings.config.getString("hubble.cassandra.hosts").split(",").toList
+  val cassandragroup = ClusterInfoApp.mapConfigToCassandraClusterGroup(system.settings.config)
+  val clusterInstance = cassandragroup.head.envs.head
 
   lazy val session: Session =
     Cluster.builder().
-      addContactPoints(hosts: _*).
+      addContactPoints(clusterInstance.hosts: _*).
       withCompression(ProtocolOptions.Compression.SNAPPY).
-      withPort(port).
-      withCredentials(username, password).
+      withPort(clusterInstance.port).
+      withCredentials(clusterInstance.uname, clusterInstance.pword).
       build().
-      connect(keyspace)
+      connect()
 }

--- a/pom.xml
+++ b/pom.xml
@@ -90,25 +90,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.1</version>
-
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.scm</groupId>
-                        <artifactId>maven-scm-provider-gitexe</artifactId>
-                        <version>1.9.2</version>
-                    </dependency>
-                </dependencies>
-
-                <configuration>
-                    <checkModificationExcludes>
-                        <checkModificationExclude>pom.xml</checkModificationExclude>
-                    </checkModificationExcludes>
-                </configuration>
-            </plugin>
         </plugins>
         <testResources>
             <testResource>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,25 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.5.1</version>
 
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.scm</groupId>
+                        <artifactId>maven-scm-provider-gitexe</artifactId>
+                        <version>1.9.2</version>
+                    </dependency>
+                </dependencies>
+
+                <configuration>
+                    <checkModificationExcludes>
+                        <checkModificationExclude>pom.xml</checkModificationExclude>
+                    </checkModificationExcludes>
+                </configuration>
+            </plugin>
         </plugins>
         <testResources>
             <testResource>


### PR DESCRIPTION
- configurations for clusters are now picked up from application.conf instead of a table on cassandra
- possibility to have multiple cluster groups
- scheduler is removed. application runs only once